### PR TITLE
Switch go.mod module name to repo URL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module argon
+module github.com/SnowyUK/argon
 
 go 1.12


### PR DESCRIPTION
This should enable others to add to their `go.mod` file as the repo URL